### PR TITLE
Introduce stable-security suite

### DIFF
--- a/bin/dr
+++ b/bin/dr
@@ -188,28 +188,22 @@ class List < ExtendedThor
       else
         suites.each do |suite, codename|
           codename = suite if codename == nil
+          colour = suite_to_colour suite
 
-          colour = case suite
-          when "stable-security" then "magenta"
-          when "stable" then "red"
-          when "testing" then "yellow"
-          when "unstable" then "green"
-          else nil end
-
-            all_included = true
-            subpkgs.each do |subpkg|
-              unless repo.query_for_deb_version(suite, subpkg) == version
-                all_included = false
-              end
+          all_included = true
+          subpkgs.each do |subpkg|
+            unless repo.query_for_deb_version(suite, subpkg) == version
+              all_included = false
             end
+          end
 
-            if all_included
-              if colour
-                line << " " + open + codename.fg(colour) + close
-              else
-                line << " " + open + codename + close
-              end
+          if all_included
+            if colour
+              line << " " + open + codename.fg(colour) + close
+            else
+              line << " " + open + codename + close
             end
+          end
         end
       end
       log :info, "  #{line}"
@@ -254,15 +248,21 @@ class List < ExtendedThor
 
     suites.each do |suite, codename|
       codename = suite if codename == nil
+      colour = suite_to_colour suite
 
-      colour = case suite
-          when "stable-security" then "magenta"
-          when "stable" then "red"
-          when "testing" then "yellow"
-          when "unstable" then "green"
-          else nil end
       log :info, "#{codename.fg colour}: #{suite}"
     end
+  end
+
+  private
+  def suite_to_colour(suite)
+    colour = case suite
+      when "stable-security" then "magenta"
+      when "stable" then "red"
+      when "testing" then "yellow"
+      when "unstable" then "green"
+      else nil end
+    return colour
   end
 end
 

--- a/bin/dr
+++ b/bin/dr
@@ -554,8 +554,8 @@ class RepoCLI < ExtendedThor
 
     log :info, "Releasing pkg #{pkg_name.style "pkg-name"} package from testing to stable-security"
 
-    if ! repo.suite_has_package? "testing", pkg_name
-      log :error, "Package  #{pkg_name.style "pkg-name"} not in testing"
+    if !repo.suite_has_package? "testing", pkg_name
+      log :err, "Package  #{pkg_name.style "pkg-name"} not in testing"
       raise "Package #{pkg_name.style "pkg-name"} doesn't exist in the repo"
     end
 
@@ -564,7 +564,7 @@ class RepoCLI < ExtendedThor
       print "Are you absolutely sure you want to push package #{pkg_name.style "pkg-name"} to stable-security?"
       response = gets.strip.downcase
       if response == 'n'
-        log :error, "Didn't confirm releasing to stable-security"
+        log :err, "Didn't confirm releasing to stable-security"
         raise "Couldn't confirm for releasing to stable-security"
       elsif response == 'y'
         log :info, "Received confirmation, will carry on"

--- a/bin/dr
+++ b/bin/dr
@@ -546,6 +546,26 @@ class RepoCLI < ExtendedThor
   end
 
 
+  desc "release-security", "Push a package from testing to stable-security suite"
+  method_option :force, :aliases => "-f", :type => :boolean,
+                :desc => "Force-push the released package"
+  def release_security(pkg_name)
+    repo = get_repo_handle
+
+    log :info, "Releasing pkg #{pkg_name.style "pkg-name"} package from testing to stable-security"
+
+    if ! repo.suite_has_package? "testing", pkg_name
+        log :error, "Pacakge  #{pkg_name.style "pkg-name"} not in testing"
+        raise "Package #{pkg_name.style "pkg-name"} doesn't exist in the repo"
+    end
+    v = repo.get_subpackage_versions(pkg_name)["testing"].values
+    begin
+      repo.push pkg_name, v.max, "stable.security", (options["force"] == true)
+    rescue Dr::AlreadyExists
+      ;
+    end
+  end
+
   desc "suite-diff", "Show the differences between packages in two suites"
   def suite_diff(first, second)
     repo = get_repo_handle

--- a/bin/dr
+++ b/bin/dr
@@ -240,7 +240,7 @@ class List < ExtendedThor
     end
   end
 
-  desc "suites", "Show the codenames of the configured suites"
+  desc "codenames", "Show the codenames of the configured suites"
   def suites
     repo = get_repo_handle
 

--- a/bin/dr
+++ b/bin/dr
@@ -556,8 +556,6 @@ class RepoCLI < ExtendedThor
   desc "release-security [pkg-name]", "Push a built package from testing to 'stable-security' suite"
   method_option :force, :aliases => "-f", :type => :boolean,
                 :desc => "Force-push the released package"
-  method_option :build, :aliases => "-b", :type => :string,
-                :desc => "which version to push (defaults to the highest one built)"
   def release_security(pkg_name)
     repo = get_repo_handle
 
@@ -574,15 +572,8 @@ class RepoCLI < ExtendedThor
     negative_msg = "Couldn't confirm for releasing to stable-security"
     prompt_to_confirm prompt_msg, negative_msg
 
-    if options.has_key? "build"
-      version = options["build"]
-      if !repo.get_subpackage_versions(pkg_name)[suite_source].value? version
-        log :err, "Suite '#{suite_source}' doesn't include the specified package version"
-        raise "Build #{version.style "version"} doesn't exist in suite '#{suite_source}'"
-      end
-    else
-      version = repo.get_subpackage_versions(pkg_name)[suite_source].values.max
-    end
+    version = repo.get_subpackage_versions(pkg_name)[suite_source].values.max
+    log :info, "Package version #{version.style "version"} found in '#{suite_source}'"
     begin
       repo.push pkg_name, version, "stable-security", (options["force"] == true)
     rescue Dr::AlreadyExists

--- a/bin/dr
+++ b/bin/dr
@@ -245,6 +245,25 @@ class List < ExtendedThor
       end
     end
   end
+
+  desc "suites", "Show the codenames of the configured suites"
+  def suites
+    repo = get_repo_handle
+
+    suites = repo.get_suites
+
+    suites.each do |suite, codename|
+      codename = suite if codename == nil
+
+      colour = case suite
+          when "stable-security" then "magenta"
+          when "stable" then "red"
+          when "testing" then "yellow"
+          when "unstable" then "green"
+          else nil end
+      log :info, "#{codename.fg colour}: #{suite}"
+    end
+  end
 end
 
 

--- a/bin/dr
+++ b/bin/dr
@@ -576,7 +576,7 @@ class RepoCLI < ExtendedThor
 
     if options.has_key? "build"
       version = options["build"]
-      if repo.get_subpackage_versions(pkg_name)[suite_source].value? version
+      if !repo.get_subpackage_versions(pkg_name)[suite_source].value? version
         log :err, "Suite '#{suite_source}' doesn't include the specified package version"
         raise "Build #{version.style "version"} doesn't exist in suite '#{suite_source}'"
       end

--- a/bin/dr
+++ b/bin/dr
@@ -562,7 +562,7 @@ class RepoCLI < ExtendedThor
     response = 'x'
     while ! ['y', 'n'].include? response
       print "Are you absolutely sure you want to push package #{pkg_name.style "pkg-name"} to stable-security?"
-      response = gets.strip.downcase
+      response = STDIN.gets.strip.downcase
       if response == 'n'
         log :err, "Didn't confirm releasing to stable-security"
         raise "Couldn't confirm for releasing to stable-security"

--- a/bin/dr
+++ b/bin/dr
@@ -190,6 +190,7 @@ class List < ExtendedThor
           codename = suite if codename == nil
 
           colour = case suite
+          when "stable-security" then "magenta"
           when "stable" then "red"
           when "testing" then "yellow"
           when "unstable" then "green"
@@ -262,7 +263,7 @@ class RepoCLI < ExtendedThor
       :desc => "",
       :arches => ["amd64"],
       :components => ["main"],
-      :suites => ["stable", "testing", "unstable"],
+      :suites => ["stable-security", "stable", "testing", "unstable"],
       :build_environment => :kano,
       :codenames => []
     }

--- a/bin/dr
+++ b/bin/dr
@@ -555,8 +555,8 @@ class RepoCLI < ExtendedThor
     log :info, "Releasing pkg #{pkg_name.style "pkg-name"} package from testing to stable-security"
 
     if ! repo.suite_has_package? "testing", pkg_name
-        log :error, "Pacakge  #{pkg_name.style "pkg-name"} not in testing"
-        raise "Package #{pkg_name.style "pkg-name"} doesn't exist in the repo"
+      log :error, "Package  #{pkg_name.style "pkg-name"} not in testing"
+      raise "Package #{pkg_name.style "pkg-name"} doesn't exist in the repo"
     end
     v = repo.get_subpackage_versions(pkg_name)["testing"].values
     begin

--- a/bin/dr
+++ b/bin/dr
@@ -731,7 +731,7 @@ class RepoCLI < ExtendedThor
     response = 'x'
     while ! ['y', 'n'].include? response
       print prompt_msg
-      print "[Y/y/N/n]: "
+      print "[y/n]: "
       response = STDIN.gets.strip.downcase
       if response == 'n'
         log :err, "Replied negatively to prompt, aborting..."

--- a/bin/dr
+++ b/bin/dr
@@ -396,6 +396,9 @@ class RepoCLI < ExtendedThor
       if options["push"] == "push"
         repo.push pkg.name, version, "testing" # FIXME: should be configurable
       else
+        if repo.codename_to_suite options["push"] == 'stable-security'
+          raise "Package built, but can't push to #{options["push"]}, use the 'release-security' subcommand"
+        end
         repo.push pkg.name, version, options["push"]
       end
     end
@@ -414,6 +417,10 @@ class RepoCLI < ExtendedThor
 
     suite = nil
     suite = options["suite"] if options.has_key? "suite"
+
+    if repo.codename_to_suite options["push"] == 'stable-security'
+      raise "Can't push package to #{options["push"]}, please use the 'release-security' subcommand"
+    end
 
     version = nil
     version = options["build"] if options.has_key? "build"
@@ -546,26 +553,38 @@ class RepoCLI < ExtendedThor
   end
 
 
-  desc "release-security", "Push a package from testing to stable-security suite"
+  desc "release-security [pkg-name]", "Push a built package from testing to 'stable-security' suite"
   method_option :force, :aliases => "-f", :type => :boolean,
                 :desc => "Force-push the released package"
+  method_option :build, :aliases => "-b", :type => :string,
+                :desc => "which version to push (defaults to the highest one built)"
   def release_security(pkg_name)
     repo = get_repo_handle
 
-    log :info, "Releasing pkg #{pkg_name.style "pkg-name"} package from testing to stable-security"
+    suite_source = 'testing'
 
-    if !repo.suite_has_package? "testing", pkg_name
-      log :err, "Package  #{pkg_name.style "pkg-name"} not in testing"
+    log :info, "Releasing pkg #{pkg_name.style "pkg-name"} package from '#{suite_source}' to 'stable-security'"
+
+    if !repo.suite_has_package? suite_source, pkg_name
+      log :err, "Package  #{pkg_name.style "pkg-name"} not in '#{suite_source}'"
       raise "Package #{pkg_name.style "pkg-name"} doesn't exist in the repo"
     end
 
-    prompt_msg = "Are you absolutely sure you want to push package #{pkg_name.style "pkg-name"} to stable-security?"
+    prompt_msg = "Are you absolutely sure you want to push package #{pkg_name.style "pkg-name"} to 'stable-security'?"
     negative_msg = "Couldn't confirm for releasing to stable-security"
     prompt_to_confirm prompt_msg, negative_msg
 
-    v = repo.get_subpackage_versions(pkg_name)["testing"].values
+    if options.has_key? "build"
+      version = options["build"]
+      if repo.get_subpackage_versions(pkg_name)[suite_source].value? version
+        log :err, "Suite '#{suite_source}' doesn't include the specified package version"
+        raise "Build #{version.style "version"} doesn't exist in suite '#{suite_source}'"
+      end
+    else
+      version = repo.get_subpackage_versions(pkg_name)[suite_source].values.max
+    end
     begin
-      repo.push pkg_name, v.max, "stable-security", (options["force"] == true)
+      repo.push pkg_name, version, "stable-security", (options["force"] == true)
     rescue Dr::AlreadyExists
       ;
     end

--- a/bin/dr
+++ b/bin/dr
@@ -66,7 +66,7 @@ class Archive < ExtendedThor
 end
 
 class Conf < ExtendedThor
-  desc "repo", "Configuration of the whole repository"
+  desc "repo KEY [VALUE]", "Configuration of the whole repository"
   def repo(key, value=nil)
     repo = get_repo_handle
 
@@ -80,7 +80,7 @@ class Conf < ExtendedThor
     end
   end
 
-  desc "package", "Package-specific configuration options"
+  desc "package PKG-NAME KEY [VALUE]", "Package-specific configuration options"
   def package(pkg_name, key, value=nil)
     repo = get_repo_handle
     pkg = repo.get_package pkg_name
@@ -150,13 +150,13 @@ class List < ExtendedThor
     end
   end
 
-  desc "versions PACKAGE", "DEPRECATED, please use builds instead"
+  desc "versions PKG-NAME", "DEPRECATED, please use builds instead"
   def versions(pkg_name)
     log :warn, "This subcommand is deprecated, please use builds instead"
     builds pkg_name
   end
 
-  desc "builds PACKAGE", "Show the history of all builds of a package"
+  desc "builds PKG-NAME", "Show the history of all builds of a package"
   def builds(pkg_name)
     repo = get_repo_handle
     log :info, "Listing all buils of #{pkg_name.style "pkg-name"}"
@@ -387,7 +387,7 @@ class RepoCLI < ExtendedThor
   end
 
 
-  desc "build [pkg-name]", "build a package from the sources"
+  desc "build PKG-NAME", "build a package from the sources"
   method_option :branch, :aliases => "-b", :type => :string,
                 :desc => "build from a different branch"
   method_option :push, :aliases => "-p", :type => :string,
@@ -424,7 +424,7 @@ class RepoCLI < ExtendedThor
   end
 
 
-  desc "push [pkg-name]", "push a built package to a specified suite"
+  desc "push PKG-NAME", "push a built package to a specified suite"
   method_option :suite, :aliases => "-s", :type => :string,
                 :desc => "the target suite (defaults to testing)"
   method_option :build, :aliases => "-b", :type => :string,
@@ -448,7 +448,7 @@ class RepoCLI < ExtendedThor
   end
 
 
-  desc "unpush [pkg-name] [suite]", "remove a built package from a suite"
+  desc "unpush PKG-NAME SUITE", "remove a built package from a suite"
   def unpush(pkg_name, suite)
     repo = get_repo_handle
     repo.unpush pkg_name, suite
@@ -472,7 +472,7 @@ class RepoCLI < ExtendedThor
   end
 
 
-  desc "rmbuild [pkg-name] [version]", "remove a built version of a package"
+  desc "rmbuild PKG-NAME VERSION", "remove a built version of a package"
   method_option :force, :aliases => "-f", :type => :boolean,
                 :desc => "force removal even if the build is still used"
   def rmbuild(pkg_name, version)
@@ -480,7 +480,7 @@ class RepoCLI < ExtendedThor
     repo.remove_build pkg_name, version, options["force"] == true
   end
 
-  desc "update", "Update and rebuild (if necessary) all the packages in the suite"
+  desc "update [SUITE]", "Update and rebuild (if necessary) all the packages in the suite"
   def update(suite="testing")
     log :info, "Updating all packages in the #{suite.fg "blue"} suite"
     repo = get_repo_handle
@@ -512,7 +512,7 @@ class RepoCLI < ExtendedThor
   end
 
 
-  desc "git-tag-release", "Mark relased packages' repositories"
+  desc "git-tag-release TAG", "Mark relased packages' repositories"
   method_option :force, :aliases => "-f", :type => :boolean,
                 :desc => "Force override existing tags"
   method_option :package, :aliases => "-p", :type => :string,
@@ -572,7 +572,7 @@ class RepoCLI < ExtendedThor
   end
 
 
-  desc "release-security [pkg-name]", "Push a built package from testing to 'stable-security' suite"
+  desc "release-security PKG-NAME", "Push a built package from testing to 'stable-security' suite"
   method_option :force, :aliases => "-f", :type => :boolean,
                 :desc => "Force-push the released package"
   def release_security(pkg_name)
@@ -600,7 +600,7 @@ class RepoCLI < ExtendedThor
     end
   end
 
-  desc "suite-diff", "Show the differences between packages in two suites"
+  desc "suite-diff SUITE OTHER-SUITE", "Show the differences between packages in two suites"
   def suite_diff(first, second)
     repo = get_repo_handle
 
@@ -639,7 +639,7 @@ class RepoCLI < ExtendedThor
   end
 
 
-  desc "force-sync", "Force cloning the sources repository from scratch again"
+  desc "force-sync PKG-NAME", "Force cloning the sources repository from scratch again"
   method_option :url, :aliases => "-u", :type => :string,
                 :desc => "The URL to clone from"
   method_option :branch, :aliases => "-b", :type => :string,

--- a/bin/dr
+++ b/bin/dr
@@ -559,19 +559,9 @@ class RepoCLI < ExtendedThor
       raise "Package #{pkg_name.style "pkg-name"} doesn't exist in the repo"
     end
 
-    response = 'x'
-    while ! ['y', 'n'].include? response
-      print "Are you absolutely sure you want to push package #{pkg_name.style "pkg-name"} to stable-security?"
-      response = STDIN.gets.strip.downcase
-      if response == 'n'
-        log :err, "Didn't confirm releasing to stable-security"
-        raise "Couldn't confirm for releasing to stable-security"
-      elsif response == 'y'
-        log :info, "Received confirmation, will carry on"
-      else
-        print "Not an acceptable answer, please answer y/n\n"
-      end
-    end
+    prompt_msg = "Are you absolutely sure you want to push package #{pkg_name.style "pkg-name"} to stable-security?"
+    negative_msg = "Couldn't confirm for releasing to stable-security"
+    prompt_to_confirm prompt_msg, negative_msg
 
     v = repo.get_subpackage_versions(pkg_name)["testing"].values
     begin
@@ -706,6 +696,25 @@ class RepoCLI < ExtendedThor
                        options["bind"], repo.get_archive_path
     s.start
   end
+
+  private
+  def prompt_to_confirm(prompt_msg, negative_message)
+    response = 'x'
+    while ! ['y', 'n'].include? response
+      print prompt_msg
+      print "[Y/y/N/n]:"
+      response = STDIN.gets.strip.downcase
+      if response == 'n'
+        log :err, "Replied negatively to prompt, aborting..."
+        raise negative_message
+      elsif response == 'y'
+        log :info, "Received confirmation, will carry on"
+      else
+        print "Not an acceptable answer, please answer y/n\n"
+      end
+    end
+  end
+
 end
 
 

--- a/bin/dr
+++ b/bin/dr
@@ -559,8 +559,8 @@ class RepoCLI < ExtendedThor
       raise "Package #{pkg_name.style "pkg-name"} doesn't exist in the repo"
     end
 
-    response = 'n'
-    while ['y', 'n'].include? response
+    response = 'x'
+    while ! ['y', 'n'].include? response
       print "Are you absolutely sure you want to push package #{pkg_name.style "pkg-name"} to stable-security?"
       response = gets.strip.downcase
       if response == 'n'
@@ -569,7 +569,7 @@ class RepoCLI < ExtendedThor
       elsif response == 'y'
         log :info, "Received confirmation, will carry on"
       else
-        print "Not an acceptable answer, please answer y/n"
+        print "Not an acceptable answer, please answer y/n\n"
       end
     end
 

--- a/bin/dr
+++ b/bin/dr
@@ -702,7 +702,7 @@ class RepoCLI < ExtendedThor
     response = 'x'
     while ! ['y', 'n'].include? response
       print prompt_msg
-      print "[Y/y/N/n]:"
+      print "[Y/y/N/n]: "
       response = STDIN.gets.strip.downcase
       if response == 'n'
         log :err, "Replied negatively to prompt, aborting..."

--- a/bin/dr
+++ b/bin/dr
@@ -560,7 +560,7 @@ class RepoCLI < ExtendedThor
     end
     v = repo.get_subpackage_versions(pkg_name)["testing"].values
     begin
-      repo.push pkg_name, v.max, "stable.security", (options["force"] == true)
+      repo.push pkg_name, v.max, "stable-security", (options["force"] == true)
     rescue Dr::AlreadyExists
       ;
     end

--- a/bin/dr
+++ b/bin/dr
@@ -558,6 +558,21 @@ class RepoCLI < ExtendedThor
       log :error, "Package  #{pkg_name.style "pkg-name"} not in testing"
       raise "Package #{pkg_name.style "pkg-name"} doesn't exist in the repo"
     end
+
+    response = 'n'
+    while ['y', 'n'].include? response
+      print "Are you absolutely sure you want to push package #{pkg_name.style "pkg-name"} to stable-security?"
+      response = gets.strip.downcase
+      if response == 'n'
+        log :error, "Didn't confirm releasing to stable-security"
+        raise "Couldn't confirm for releasing to stable-security"
+      elsif response == 'y'
+        log :info, "Received confirmation, will carry on"
+      else
+        print "Not an acceptable answer, please answer y/n"
+      end
+    end
+
     v = repo.get_subpackage_versions(pkg_name)["testing"].values
     begin
       repo.push pkg_name, v.max, "stable-security", (options["force"] == true)

--- a/bin/dr
+++ b/bin/dr
@@ -415,7 +415,7 @@ class RepoCLI < ExtendedThor
       if options["push"] == "push"
         repo.push pkg.name, version, "testing" # FIXME: should be configurable
       else
-        if repo.codename_to_suite options["push"] == 'stable-security'
+        if repo.codename_to_suite(options["push"]) == 'stable-security'
           raise "Package built, but can't push to #{options["push"]}, use the 'release-security' subcommand"
         end
         repo.push pkg.name, version, options["push"]
@@ -437,8 +437,8 @@ class RepoCLI < ExtendedThor
     suite = nil
     suite = options["suite"] if options.has_key? "suite"
 
-    if repo.codename_to_suite options["push"] == 'stable-security'
-      raise "Can't push package to #{options["push"]}, please use the 'release-security' subcommand"
+    if repo.codename_to_suite(options["suite"]) == 'stable-security'
+      raise "Can't push package to #{options["suite"]}, please use the 'release-security' subcommand"
     end
 
     version = nil

--- a/lib/dr/logger.rb
+++ b/lib/dr/logger.rb
@@ -14,6 +14,7 @@ tco_conf.names["purple"] = "#90559e"
 tco_conf.names["blue"] = "#4D9EEB" #"#1b8efa"
 tco_conf.names["orange"] = "#ff842a"
 tco_conf.names["brown"] = "#6a4a3c"
+tco_conf.names["magenta"] = "#ff00ff"
 
 tco_conf.styles["info"] = {
   :fg => "green",

--- a/lib/dr/version.rb
+++ b/lib/dr/version.rb
@@ -2,5 +2,5 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 
 module Dr
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
This PR introduces a fourth suite in dr named `stable-security`. Pushing to this suite is only allowed through the new `release-security` subcommand which should force a specific operation process.

Furthermore, it standardises the descriptions of the commands using capitals for all arguments and also
encloses the required ones in square brackets.

As a result of the magnitude of the changes the package is bumped to 1.2.0