### PR TITLE
Add jessie base

### DIFF
--- a/lib/dr/build_environments.rb
+++ b/lib/dr/build_environments.rb
@@ -36,6 +36,38 @@ module Dr
         :packages => []
       },
 
+      :kano_jessie => {
+        :name =>"Kano OS (Jessie)",
+        :arches => ["armhf"],
+        :repos => {
+          :raspbian_jessie => {
+            :url => "http://mirror.ox.ac.uk/sites/archive.raspbian.org/archive/raspbian/",
+            :key => "http://mirror.ox.ac.uk/sites/archive.raspbian.org/archive/raspbian.public.key",
+            :src => true,
+            :codename => "jessie",
+            :components => "main contrib non-free rpi"
+          },
+
+          :raspi_foundation_jessie => {
+            :url => "http://dev.kano.me/mirrors/raspberrypi/",
+            :key => "http://dev.kano.me/mirrors/raspberrypi/raspberrypi.gpg.key",
+            :src => false,
+            :codename => "jessie",
+            :components => "main"
+          },
+
+          :kano_jessie => {
+            :url => "http://dev.kano.me/archive-jessie/",
+            :key => "http://dev.kano.me/archive-jessie/repo.gpg.key",
+            :src => false,
+            :codename => "devel",
+            :components => "main"
+          }
+        },
+        :base_repo => :raspbian_jessie,
+        :packages => []
+      },
+
       :wheezy => {
         :name => "Debian Wheezy",
         :arches => ["x86_64"],
@@ -45,6 +77,22 @@ module Dr
             :key => "https://ftp-master.debian.org/keys/archive-key-7.0.asc",
             :src => true,
             :codename => "wheezy",
+            :components => "main contrib non-free"
+          }
+        },
+        :base_repo => :wheezy,
+        :packages => []
+      },
+
+      :jessie => {
+        :name => "Debian Jessie",
+        :arches => ["x86_64"],
+        :repos => {
+          :wheezy => {
+            :url => "http://ftp.uk.debian.org/debian/",
+            :key => "https://ftp-master.debian.org/keys/archive-key-8.0.asc",
+            :src => true,
+            :codename => "jessie",
             :components => "main contrib non-free"
           }
         },

--- a/lib/dr/build_environments.rb
+++ b/lib/dr/build_environments.rb
@@ -90,7 +90,7 @@ module Dr
         :repos => {
           :wheezy => {
             :url => "http://ftp.uk.debian.org/debian/",
-            :key => "https://ftp-master.debian.org/keys/archive-key-8.0.asc",
+            :key => "https://ftp-master.debian.org/keys/archive-key-8.asc",
             :src => true,
             :codename => "jessie",
             :components => "main contrib non-free"

--- a/lib/dr/version.rb
+++ b/lib/dr/version.rb
@@ -2,5 +2,5 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 
 module Dr
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
This should enable the creation of repositories that are based on Debian or the raspbian jessie.