### PR TITLE
Look for repository conf file when using --repo

### DIFF
--- a/bin/dr
+++ b/bin/dr
@@ -37,7 +37,7 @@ class ExtendedThor < Thor
 
   def get_repo_handle
     if options.has_key? "repo"
-      Dr::Repo.new options["repo"]
+      Dr::Repo.new Dr.config.repositories[options["repo"]][:location]
     else
       if Dr.config.default_repo != nil
         Dr::Repo.new Dr.config.repositories[Dr.config.default_repo][:location]

--- a/bin/dr
+++ b/bin/dr
@@ -37,7 +37,11 @@ class ExtendedThor < Thor
 
   def get_repo_handle
     if options.has_key? "repo"
-      Dr::Repo.new Dr.config.repositories[options["repo"]][:location]
+        if Dr.config.repositories.has_key? options["repo"]
+          Dr::Repo.new Dr.config.repositories[options["repo"]][:location]
+        else
+          Dr::Repo.new options["repo"]
+        end
     else
       if Dr.config.default_repo != nil
         Dr::Repo.new Dr.config.repositories[Dr.config.default_repo][:location]


### PR DESCRIPTION
Currently the repo option specifies a directory on which is to be used.
This commit changes this behaviour to use the name given in the
conf file