### PR TITLE
dr list builds: Fix typo with CLI output

### DIFF
--- a/bin/dr
+++ b/bin/dr
@@ -163,7 +163,7 @@ class List < ExtendedThor
   desc "builds PKG-NAME", "Show the history of all builds of a package"
   def builds(pkg_name)
     repo = get_repo_handle
-    log :info, "Listing all buils of #{pkg_name.style "pkg-name"}"
+    log :info, "Listing all builds of #{pkg_name.style "pkg-name"}"
 
     suites = repo.get_suites
 


### PR DESCRIPTION
The CLI output from `dr list builds <pkgname>` includes:

```
Listing all buils of #{pkg_name.style "pkg-name"}
```

In this `builds` is misspelt so correct the output.

@pazdera This is only minor so if it will kick off some re-gemifying or updaing then don't worry about merging it until there is something more major which warrants a version increase.