### PR TITLE
Tweak orig.tar build 

### DIFF
--- a/lib/dr/gitpackage.rb
+++ b/lib/dr/gitpackage.rb
@@ -234,11 +234,11 @@ module Dr
 
             # Make orig tarball
             all_files = Dir["#{build_dir}/*"] + Dir["#{build_dir}/.*"]
-            excluded_files = ['.', '..', '.git']
+            excluded_files = ['.', '..', '.git', 'debian']
             selected_files = all_files.select { |path| !excluded_files.include?(File.basename(path)) }
             files = selected_files.map { |f| "\"#{File.basename f}\"" }.join " "
             log :info, "Creating orig source tarball"
-            tar = "tar cz -C #{build_dir} --exclude=debian " +
+            tar = "tar cz -C #{build_dir} " +
                   "-f #{br}/#{@name}_#{version.upstream}.orig.tar.gz " +
                   "#{files}"
             ShellCmd.new tar, :tag => "tar"


### PR DESCRIPTION
This PR is necessary to build love2d, which has a debian directory in a subdirectory.
Currently dr is removing anything named. 'This changes it to not remove debian directory other than in the root, otherwise dpkg-source is confused. @pazdera 