### PR TITLE
Extra suites

### DIFF
--- a/bin/dr
+++ b/bin/dr
@@ -577,15 +577,31 @@ class RepoCLI < ExtendedThor
   end
 
 
-  desc "release", "Push all the packages from testing to release"
+  desc "release RC-SUITE", "Push all the packages from testing to release"
   method_option :force, :aliases => "-f", :type => :boolean,
                 :desc => "Force-push all released packages"
-  def release
+  def release(rc_suite=nil)
+    if rc_suite.nil?
+      log :err, "#{"DEPRECATED".fg('red')}, suite required. Doing nothing."
+      log :err, "Use '#{"dr release RC-SUITE".fg("yellow")}' instead."
+      raise "Running '#{"dr release".fg("yellow")}' command without suite deprecated"
+
+      return
+    end
+
     repo = get_repo_handle
+    suite = repo.codename_to_suite rc_suite
+
+    if suite.nil?
+      log :err, "Suite '#{rc_suite.fg("yellow")}' not found"
+      raise "Suite '#{rc_suite.fg("yellow")}' doesn't exist in the repo"
+
+      return
+    end
 
     log :info, "Releasing all packages from testing"
-    repo.list_packages("testing").each do |pkg|
-      v = repo.get_subpackage_versions(pkg.name)["testing"].values
+    repo.list_packages(suite).each do |pkg|
+      v = repo.get_subpackage_versions(pkg.name)[suite].values
       begin
         repo.push pkg.name, v.max, "stable", (options["force"] == true)
       rescue Dr::AlreadyExists
@@ -595,7 +611,7 @@ class RepoCLI < ExtendedThor
 
     log :info, "Removing packages that are not in testing any more"
     repo.list_packages("release").each do |pkg|
-      if ! repo.suite_has_package? "testing", pkg.name
+      if ! repo.suite_has_package? suite, pkg.name
         repo.unpush pkg.name, "release"
       end
     end

--- a/bin/dr
+++ b/bin/dr
@@ -585,8 +585,6 @@ class RepoCLI < ExtendedThor
       log :err, "#{"DEPRECATED".fg('red')}, suite required. Doing nothing."
       log :err, "Use '#{"dr release RC-SUITE".fg("yellow")}' instead."
       raise "Running '#{"dr release".fg("yellow")}' command without suite deprecated"
-
-      return
     end
 
     repo = get_repo_handle
@@ -595,24 +593,29 @@ class RepoCLI < ExtendedThor
     if suite.nil?
       log :err, "Suite '#{rc_suite.fg("yellow")}' not found"
       raise "Suite '#{rc_suite.fg("yellow")}' doesn't exist in the repo"
-
-      return
     end
+
+    release_suite = "stable"
+    release_codename = repo.suite_to_codename release_suite
+
+    log :info, "Pushing packages from #{rc_suite.fg("yellow")} to #{release_codename.fg("yellow")}"
+    suite_diff rc_suite, release_codename
+    prompt_to_confirm "Are you sure you want to continue?", "Aborting release"
 
     log :info, "Releasing all packages from testing"
     repo.list_packages(suite).each do |pkg|
       v = repo.get_subpackage_versions(pkg.name)[suite].values
       begin
-        repo.push pkg.name, v.max, "stable", (options["force"] == true)
+        repo.push pkg.name, v.max, release_suite, (options["force"] == true)
       rescue Dr::AlreadyExists
         ;
       end
     end
 
     log :info, "Removing packages that are not in testing any more"
-    repo.list_packages("release").each do |pkg|
+    repo.list_packages(release_codename).each do |pkg|
       if ! repo.suite_has_package? suite, pkg.name
-        repo.unpush pkg.name, "release"
+        repo.unpush pkg.name, release_codename
       end
     end
   end

--- a/bin/dr
+++ b/bin/dr
@@ -265,7 +265,7 @@ class List < ExtendedThor
       when "stable" then "red"
       when "testing" then "yellow"
       when "unstable" then "green"
-      else nil end
+      else "cyan" end
     return colour
   end
 end

--- a/bin/dr
+++ b/bin/dr
@@ -360,6 +360,32 @@ class RepoCLI < ExtendedThor
       repo_conf[:codenames].push codename
     end
 
+    # TODO: Add CLI command to add suites
+    extra_suite_count = ask "   Additional suites [#{'0'.fg("yellow")}]:"
+    extra_suite_count.to_i.times do |idx|
+      suite_name = nil
+      loop do
+        suite_name = ask "   Suite #{idx + 1} name (#{"required".fg("red")}):"
+        if repo_conf[:suites].include? suite_name
+          log :warn, "Suite already exists, try again".fg("red")
+          next
+        end
+        break unless suite_name.empty?
+      end
+      repo_conf[:suites].push suite_name
+
+      codename = nil
+      loop do
+        codename = ask "   Codename for suite #{idx + 1} (#{"required".fg("red")}):"
+        if repo_conf[:codenames].include? codename
+          log :warn, "Codename already exists, try again".fg("red")
+          next
+        end
+        break unless codename.empty?
+      end
+      repo_conf[:codenames].push codename
+    end
+
     r = Dr::Repo.new location
     r.setup repo_conf
   end

--- a/lib/dr/repo.rb
+++ b/lib/dr/repo.rb
@@ -389,6 +389,14 @@ module Dr
       nil
     end
 
+    def suite_to_codename(codename_or_suite)
+      get_suites.each do |suite, codename|
+        return codename if codename_or_suite == suite || codename_or_suite == codename
+      end
+
+      nil
+    end
+
     def is_used?(pkg_name, version=nil)
       versions_by_suite = get_subpackage_versions pkg_name
       versions_by_suite.inject(false) do |rslt, hash_pair|

--- a/lib/dr/version.rb
+++ b/lib/dr/version.rb
@@ -2,5 +2,5 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 
 module Dr
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end


### PR DESCRIPTION
Give the option at initialisation to create arbitrarily many extra suites.

Also modifies the release command to release with a given suite as the source for the release (and modifies the interface to require that such a suite is provided). Adds a confirmation step to the release with a full diff of the suites output before asking for confirmation.

Intended to achieve a similar result to https://github.com/KanoComputing/kano-repository-manager/pull/55 (permit adding extra suites).

@pazdera @convolu To review.