### PR TITLE
[WIP] Default Branches: Permit repos to have a default branch

### DIFF
--- a/bin/dr
+++ b/bin/dr
@@ -288,7 +288,8 @@ class RepoCLI < ExtendedThor
       :components => ["main"],
       :suites => ["stable-security", "stable", "testing", "unstable"],
       :build_environment => :kano,
-      :codenames => []
+      :codenames => [],
+      :default_branches => []
     }
 
     name = ask "   Repository name "<< "[#{repo_conf[:name].fg("yellow")}]:"
@@ -358,6 +359,8 @@ class RepoCLI < ExtendedThor
     repo_conf[:suites].each do |s|
       codename = ask "   Codename for '#{s.fg("yellow")}':"
       repo_conf[:codenames].push codename
+      default_branch = ask "   Default branch for '#{s.fg("yellow")}':"
+      repo_conf[:default_branches].push default_branch
     end
 
     r = Dr::Repo.new location
@@ -493,7 +496,7 @@ class RepoCLI < ExtendedThor
     repo.list_packages(suite).each do |pkg|
       log :info, "Updating #{pkg.name.style "pkg-name"}"
       begin
-        version = pkg.build
+        version = pkg.build :suite => suite
       rescue Dr::Package::UnableToBuild
         log :info, ""
         next

--- a/lib/dr/gitpackage.rb
+++ b/lib/dr/gitpackage.rb
@@ -67,7 +67,10 @@ module Dr
     def initialize(name, repo)
       super name, repo
 
-      @git_dir = "#{repo.location}/packages/#{name}/source"
+      @pkg_dir = "#{repo.packages_dir}/#{name}"
+      @git_dir = "#{pkg_dir}/source"
+      @pkg_metadata_path = "#{@pkg_dir}/metadata"
+
       @default_branch = get_current_branch
     end
 
@@ -122,9 +125,8 @@ module Dr
     end
 
     def get_configuration
-      md_file = "#{@repo.location}/packages/#{@name}/metadata"
-      if File.exists? md_file
-        Utils::symbolise_keys YAML.load_file md_file
+      if File.exists? @pkg_metadata_path
+        Utils::symbolise_keys YAML.load_file @pkg_metadata_path
       else
         {}
       end
@@ -132,8 +134,7 @@ module Dr
 
     def set_configuration(config)
       # TODO: Some validation needed
-      md_file = "#{@repo.location}/packages/#{@name}/metadata"
-      File.open(md_file, "w") do |f|
+      File.open(@pkg_metadata_path, "w") do |f|
         YAML.dump Utils::stringify_symbols(config), f
       end
     end


### PR DESCRIPTION
https://trello.com/c/MAJSh2Bd/219-3-make-a-rc-package-build-script-or-modify-dr-so-dr-update-can-work-from-a-specific-branch

Currently, the way of determining which branch should be used, should
the branch CLI option not be provided, is to use the currently checked
out branch. This makes it difficult to specify a policy for a suite, or
even have a different branch for each suite.

Add the beginnings of an approach to permit default branches to be
specified by providing an option in the suite definitions which can be
overridden by the package specific options.

@pazdera I'm looking for comments here as I'm not certain that I've gone
the correct route. Also, I had some troubles deciding what the default
behaviour should be so that we maintain backwards compatibility with
repos which do not know about the setting.