### PR TITLE
Update: Permit `dr update` with a branch to use

### DIFF
--- a/bin/dr
+++ b/bin/dr
@@ -485,15 +485,18 @@ class RepoCLI < ExtendedThor
   end
 
   desc "update [SUITE]", "Update and rebuild (if necessary) all the packages in the suite"
+  method_option :branch, :aliases => "-b", :type => :string,
+                :desc => "Branch to use as the source for update"
   def update(suite="testing")
     log :info, "Updating all packages in the #{suite.fg "blue"} suite"
     repo = get_repo_handle
+    branch = options["branch"] if options.has_key? "branch"
 
     updated = 0
     repo.list_packages(suite).each do |pkg|
       log :info, "Updating #{pkg.name.style "pkg-name"}"
       begin
-        version = pkg.build
+        version = pkg.build :branch => branch
       rescue Dr::Package::UnableToBuild
         log :info, ""
         next


### PR DESCRIPTION
Functionality required for https://trello.com/c/MAJSh2Bd/219-3-make-a-rc-package-build-script-or-modify-dr-so-dr-update-can-work-from-a-specific-branch until the more ideal solution (https://github.com/KanoComputing/kano-repository-manager/pull/68) can be merged in.

By default, `dr update` will take the default branch used for the repo
to perform the update. This doesn't allow suites to be mirrored off of
git branches. Modify the command to permit a branch to be provided which
will be used as the base for building.

cc @pazdera 