### PR TITLE
Release: Fix typo which prevents displaying variable

### DIFF
--- a/bin/dr
+++ b/bin/dr
@@ -612,7 +612,7 @@ class RepoCLI < ExtendedThor
       end
     end
 
-    log :info, "Removing packages that are not in {#rc_suite} any more"
+    log :info, "Removing packages that are not in #{rc_suite} any more"
     repo.list_packages(release_codename).each do |pkg|
       if ! repo.suite_has_package? suite, pkg.name
         repo.unpush pkg.name, release_codename


### PR DESCRIPTION
There is a log message which attempts to print a variable but because of
a typo, fails to do so. Fix this.

@Ealdwulf This was the typo that we spotted earlier.