### PR TITLE
Fix because branch is not a keyword arg to pkg.build.

### DIFF
--- a/bin/dr
+++ b/bin/dr
@@ -522,7 +522,7 @@ class RepoCLI < ExtendedThor
     repo.list_packages(suite).each do |pkg|
       log :info, "Updating #{pkg.name.style "pkg-name"}"
       begin
-        version = pkg.build :branch => branch
+        version = pkg.build branch
       rescue Dr::Package::UnableToBuild
         log :info, ""
         next


### PR DESCRIPTION
Previous PR was incorrect - branch isn't a keyword arg.
@tombettany @pazdera 
