### PR TITLE
Performance: Run lengthy tasks in threads

### DIFF
--- a/bin/dr
+++ b/bin/dr
@@ -18,6 +18,7 @@ require "dr/shellcmd"
 require "dr/logger"
 require "dr/config"
 require "dr/server"
+require "dr/threadpool"
 
 
 class ExtendedThor < Thor
@@ -730,25 +731,26 @@ class RepoCLI < ExtendedThor
       log :info, "Only for Deb packages"
     end
 
-    repo.list_packages(first).each do |pkg|
-      first_v = repo.get_subpackage_versions(pkg.name)[first].values.max
-
+    thread_pool repo.list_packages(first) do |pkg|
       if options["deb"] and not pkg.is_a? Dr::DebPackage
          next
       end
 
+      subpackage_versions = repo.get_subpackage_versions pkg.name
+
+      first_v = subpackage_versions[first].values.max
       if !repo.suite_has_package? second, pkg.name
         log :info, "#{pkg.name.fg 'orange'} is in #{first.fg 'green'} but not in #{second.fg 'red'}"
         next
       end
 
-      second_v = repo.get_subpackage_versions(pkg.name)[second].values.max
+      second_v = subpackage_versions[second].values.max
       if Dr::PkgVersion.new(first_v) != Dr::PkgVersion.new(second_v)
         log :info, "#{pkg.name.fg 'orange'} #{first_v.fg 'green'} != #{second_v.fg 'red'}"
       end
     end
 
-    repo.list_packages(second).each do |pkg|
+    thread_pool repo.list_packages(second) do |pkg|
       if !repo.suite_has_package? first, pkg.name
         log :info, "#{pkg.name.fg 'orange'} is in #{second.fg 'red'} but not in #{first.fg 'green'}"
       end

--- a/lib/dr/logger.rb
+++ b/lib/dr/logger.rb
@@ -1,7 +1,8 @@
-# Copyright (C) 2014 Kano Computing Ltd.
+# Copyright (C) 2014-2017 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 
 require "tco"
+require "thread"
 
 tco_conf = Tco::config
 
@@ -89,6 +90,7 @@ module Dr
       :verbose => 3
     }
 
+    @@stdout_mutex = Mutex.new
     @@log_file = nil
 
     def self.set_logfile(file)
@@ -122,12 +124,15 @@ module Dr
 
       if verbosity <= @@verbosity
         out << " " << msg.chomp
-        puts out
-        STDOUT.flush
 
-        unless @@log_file.nil?
-           @@log_file.puts strip_colours out
-           @@log_file.flush
+        @@stdout_mutex.synchronize do
+          puts out
+          STDOUT.flush
+
+          unless @@log_file.nil?
+            @@log_file.puts strip_colours out
+            @@log_file.flush
+          end
         end
       end
     end

--- a/lib/dr/shellcmd.rb
+++ b/lib/dr/shellcmd.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 Kano Computing Ltd.
+# Copyright (C) 2014-2017 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 
 require "open3"
@@ -50,6 +50,7 @@ module Dr
           end
         end
 
+        wait_thr.join
         @status = wait_thr.value
       end
 

--- a/lib/dr/threadpool.rb
+++ b/lib/dr/threadpool.rb
@@ -1,0 +1,26 @@
+# Copyright (C) 2017 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPLv2
+
+
+require "thread"
+
+def thread_pool(items, worker_count=8)
+  work_queue = Queue.new
+  items.each { |item| work_queue.push item }
+
+  threads = (0 .. worker_count).map do
+    Thread.new do
+      begin
+        # Passing `true` causes the queue to raise an exception if it is empty
+        # rather than block, waiting for something to add to it.
+        while item = work_queue.pop(true)
+          yield item
+        end
+      rescue ThreadError
+        # The work_queue is empty, we are done
+      end
+    end
+  end
+
+  threads.map(&:join)
+end


### PR DESCRIPTION
Utilise a thread pool for running tasks which outsource computation to
the `reprepro` CLI tool which waits while the shell command returns and
the output is parsed. Apply this fully to the `suite-diff` command, and
as a side-effect for any command which at some point utilises the
`Repo::list_packages()` function, to dramatically reduce the time taken
to run.

Test results reduced the `suite-diff` time from ~10 minutes to ~100
seconds.