### PR TITLE
ShellCmd: Fix duplication when redirecting stdout

### DIFF
--- a/lib/dr/shellcmd.rb
+++ b/lib/dr/shellcmd.rb
@@ -1,5 +1,5 @@
-# Copyright (C) 2014-2017 Kano Computing Ltd.
-# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+# Copyright (C) 2014-2018 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 
 require "open3"
 require "tco"
@@ -45,7 +45,7 @@ module Dr
         while line = stdouterr.gets
           @out += line
           if @show_out
-            line = tag(@tag, line) if @tag
+            line = tag(@tag.dup, line) if @tag
             log(:info, line)
           end
         end


### PR DESCRIPTION
When running `Dr::ShellCmd.new cmd, :tag => "mytag", :show_out => true`
from a script whose stdout is being redirected to a file (i.e.
`./script.rb > out.log`), the output file would end up creating repeated
lines; for example, if the output from running the command is

```
output line 1
output line 2
output line 3
```

The resultant output file would contain

```
output line 1
output line 1
output line 2
output line 1
output line 2
output line 3
```

This problem occurs when the tag is format marked multiple times. The
instance tag variable was being used multiple times and so fell into
this regime. Resolve this by creating a copy every time the formatting
will be applied.