### PR TITLE
[OS-582] Repo: Add mutex lock for reprepro calls

### DIFF
--- a/lib/dr/version.rb
+++ b/lib/dr/version.rb
@@ -1,6 +1,6 @@
-# Copyright (C) 2014-2016 Kano Computing Ltd.
+# Copyright (C) 2014-2018 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 
 module Dr
-  VERSION = "1.3.3"
+  VERSION = "1.3.4"
 end


### PR DESCRIPTION
When querying packages for their versions, a series of threads are
created to speed up the process and each calls the appropriate
`reprepro` command to query this information. This would occasionally
fail as only one command can run at a time so the original strategy was
to retry a few times. Instead of this, create a mutex for the command
and acquire that before attempting to completely avoid problems.