### PR TITLE
[OS-584] Package: Construct version history with Debian comparison

### DIFF
--- a/lib/dr/package.rb
+++ b/lib/dr/package.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 Kano Computing Ltd.
+# Copyright (C) 2014-2018 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 
 require "dr/logger"
@@ -30,7 +30,9 @@ module Dr
         versions.push v unless v =~ /^\./
       end
 
-      versions.sort.reverse
+      versions.sort { |a, b|
+        Dr::PkgVersion.new(a) <=> Dr::PkgVersion.new(b)
+      }.reverse
     end
 
     def build_exists?(version)

--- a/lib/dr/pkgversion.rb
+++ b/lib/dr/pkgversion.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2014, 2015 Kano Computing Ltd.
+# Copyright (C) 2014-2018 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 
 module Dr
@@ -80,6 +80,10 @@ module Dr
 
     def ==(o)
       compare(o) == 0
+    end
+
+    def <=>(o)
+      compare(o)
     end
 
     def to_s(omit_epoch=false)


### PR DESCRIPTION
The package version history was being constructed via the built-in
`sort` function which doesn't understand Debian versioning. Instead
utilise the Debian version comparison operators.