### PR TITLE
[OS-867] Sources: Build from Kano mirrors instead of 3rd party ones

### DIFF
--- a/lib/dr/build_environments.rb
+++ b/lib/dr/build_environments.rb
@@ -1,11 +1,11 @@
-# Copyright (C) 2014 Kano Computing Ltd.
-# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+# Copyright (C) 2014-2019 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 
 module Dr
   module BuildEnvironments
     @@build_environments = {
       :kano => {
-        :name =>"Kano OS",
+        :name =>"Kano OS (Wheezy)",
         :arches => ["armhf"],
         :repos => {
           :raspbian => {
@@ -40,17 +40,29 @@ module Dr
         :name =>"Kano OS (Stretch)",
         :arches => ["armhf"],
         :repos => {
+          :stretch_bootstrap => {
+            # This is used to debootstrap the system which suffers from the
+            # problem that S3 doesn't like serving URLs with `+` in the path
+            # so use the proxied version of:
+            #     staging.stretch.raspbian.repo.os.kano.me
+            :url => "http://build.os.kano.me/",
+            :key => "http://build.os.kano.me/raspbian.public.key",
+            :src => true,
+            :codename => "stretch",
+            :components => "main contrib non-free rpi",
+            :build_only => true
+          },
           :raspbian_stretch => {
-            :url => "http://www.mirrorservice.org/sites/archive.raspbian.org/raspbian/",
-            :key => "http://www.mirrorservice.org/sites/archive.raspbian.org/raspbian.public.key",
+            :url => "http://staging.stretch.raspbian.repo.os.kano.me/",
+            :key => "http://staging.stretch.raspbian.repo.os.kano.me/raspbian.public.key",
             :src => true,
             :codename => "stretch",
             :components => "main contrib non-free rpi"
           },
 
           :raspi_foundation_stretch => {
-            :url => "http://dev.kano.me/mirrors/raspberrypi-stretch/",
-            :key => "http://dev.kano.me/mirrors/raspberrypi-stretch/raspberrypi.gpg.key",
+            :url => "http://dev.kano.me/raspberrypi-stretch/",
+            :key => "http://dev.kano.me/raspberrypi-stretch/raspberrypi.gpg.key",
             :src => false,
             :codename => "stretch",
             :components => "main"
@@ -64,7 +76,7 @@ module Dr
             :components => "main"
           }
         },
-        :base_repo => :raspbian_stretch,
+        :base_repo => :stretch_bootstrap,
         :packages => []
       },
 
@@ -73,16 +85,16 @@ module Dr
         :arches => ["armhf"],
         :repos => {
           :raspbian_jessie => {
-            :url => "http://www.mirrorservice.org/sites/archive.raspbian.org/raspbian/",
-            :key => "http://www.mirrorservice.org/sites/archive.raspbian.org/raspbian.public.key",
+            :url => "http://staging.jessie.raspbian.repo.os.kano.me/",
+            :key => "http://staging.jessie.raspbian.repo.os.kano.me/raspbian.public.key",
             :src => true,
             :codename => "jessie",
             :components => "main contrib non-free rpi"
           },
 
           :raspi_foundation_jessie => {
-            :url => "http://dev.kano.me/mirrors/raspberrypi-jessie/",
-            :key => "http://dev.kano.me/mirrors/raspberrypi-jessie/raspberrypi.gpg.key",
+            :url => "http://dev.kano.me/raspberrypi-jessie/",
+            :key => "http://dev.kano.me/raspberrypi-jessie/raspberrypi.gpg.key",
             :src => false,
             :codename => "jessie",
             :components => "main"

--- a/lib/dr/buildroot.rb
+++ b/lib/dr/buildroot.rb
@@ -1,5 +1,5 @@
-# Copyright (C) 2014 Kano Computing Ltd.
-# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+# Copyright (C) 2014-2019 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 
 require "tco"
 
@@ -98,7 +98,9 @@ module Dr
 
           log :info, "Configuring the build root"
 
-          repo_setup_sequences = repos.map do |name, repo|
+          repo_setup_sequences = repos.reject { |name, repo|
+              repo.key? :build_only and repo[:build_only]
+          }.map do |name, repo|
             seq = "echo 'deb #{repo[:url]} #{repo[:codename]} " +
                   "#{repo[:components]}' >> /etc/apt/sources.list\n"
 
@@ -115,6 +117,7 @@ module Dr
           end
 
           cmd = "sudo chroot #{broot} <<EOF
+            rm /etc/apt/sources.list
             #{repo_setup_sequences.join "\n\n"}
 
             echo 'en_US.UTF-8 UTF-8' >/etc/locale.gen

--- a/lib/dr/version.rb
+++ b/lib/dr/version.rb
@@ -1,6 +1,6 @@
-# Copyright (C) 2014-2018 Kano Computing Ltd.
+# Copyright (C) 2014-2019 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 
 module Dr
-  VERSION = "1.3.4"
+  VERSION = "1.3.5"
 end


### PR DESCRIPTION
Kano has a full mirror of the Raspbian sources which can guarantee
reproducible builds but the packages were using the 3rd party sources.
To change the build root to use the Kano sources, add an option to the
build sources to mark them as being for `build_only` and also completely
rewrite the `debootstrap`ed sources to ensure that the final sources
contain exactly what is expected.