### PR TITLE
[OS-1023] Build: Pass environment variables to build

### DIFF
--- a/dr.gemspec
+++ b/dr.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack", "~> 1.6", ">= 1.6.4"
   spec.add_dependency "thin", "~> 1.6", ">= 1.6.3"
 
-  spec.add_development_dependency "bundler", "~> 1.11", ">= 1.11.2"
+  spec.add_development_dependency "bundler", "~> 2.0", ">= 2.0.1"
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "rspec", "~> 3.1"
 end

--- a/lib/dr/gitpackage.rb
+++ b/lib/dr/gitpackage.rb
@@ -259,9 +259,9 @@ rm -rf #{@name}-build-deps_*
 EOF
 EOS
           build = <<-EOS
-sudo chroot #{br} <<EOF
+sudo chroot -E #{br} <<EOF
 cd /#{build_dir_name}
-debuild -i -uc -us -b
+debuild --preserve-env -i -uc -us -b
 EOF
 EOS
 

--- a/lib/dr/version.rb
+++ b/lib/dr/version.rb
@@ -2,5 +2,5 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 
 module Dr
-  VERSION = "1.3.5"
+  VERSION = "1.3.6"
 end


### PR DESCRIPTION
A mechanism to pass credentials and other secrets into a build is
through environment variables. In its current implementation, these are
stripped out from the build so cannot be used. Enable this by allowing
the variables through both the `chroot` and the `debuild`.