### PR TITLE
Clean the apt cache before building a package

### DIFF
--- a/lib/dr/gitpackage.rb
+++ b/lib/dr/gitpackage.rb
@@ -250,6 +250,7 @@ module Dr
               tar = "tar cz -C #{build_dir} -f #{br}/#{@name}_#{version.upstream}.orig.tar.gz #{files}"
               ShellCmd.new tar, :tag => "tar"
 
+              clean = "sudo chroot #{br} apt-get clean"
               apt = "sudo chroot #{br} apt-get update"
               deps = <<-EOS
 sudo chroot #{br} <<EOF
@@ -265,8 +266,11 @@ debuild --preserve-env -i -uc -us -b
 EOF
 EOS
 
+              log :info, "Clean the apt cache"
+              ShellCmd.new clean, :tag => "apt-get-clean", :show_out => true
+
               log :info, "Updating the sources lists"
-              ShellCmd.new apt, :tag => "apt-get", :show_out => true
+              ShellCmd.new apt, :tag => "apt-get-update", :show_out => true
 
               log :info, "Installing build dependencies"
               ShellCmd.new deps, :tag => "mk-build-deps", :show_out => true

--- a/lib/dr/version.rb
+++ b/lib/dr/version.rb
@@ -2,5 +2,5 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 
 module Dr
-  VERSION = "1.3.6"
+  VERSION = "1.3.7"
 end


### PR DESCRIPTION
This should ensure the cache is clean before updating, downloading,
and installing any dependencies during package build. It should
hopefully aid in preventing hashsum mismatch errors.

---

I'm unsure whether the build Gods have decided to smile upon me whilst I was trying out this change in a container or it actually helped the problem. Either way, my package built with it and it can't hurt anyway.