### PR TITLE
Second attempt at preventing hashsum mismatches...

### DIFF
--- a/lib/dr/gitpackage.rb
+++ b/lib/dr/gitpackage.rb
@@ -255,11 +255,14 @@ module Dr
               deps = <<-EOS
 sudo chroot #{br} <<EOF
 dpkg-source -b "/#{build_dir_name}"
-mk-build-deps *.dsc -i -t "apt-get --no-install-recommends -y"
+cd #{build_dir_name}
+apt-get build-dep --download-only --yes ../*.dsc
+apt-get build-dep --fix-broken --no-install-recommends --yes ../*.dsc
+cd ..
 rm -rf #{@name}-build-deps_*
 EOF
 EOS
-          build = <<-EOS
+              build = <<-EOS
 sudo -E chroot #{br} <<EOF
 cd /#{build_dir_name}
 debuild --preserve-env -i -uc -us -b


### PR DESCRIPTION
 - Replace `mk-build-deps` with `apt-get build-dep` to do the same task
 - Split the installation of build deps into a download phase and install phase