### PR TITLE
Chroot: Add backup build dependency acquisition

### DIFF
--- a/lib/dr/gitpackage.rb
+++ b/lib/dr/gitpackage.rb
@@ -252,6 +252,11 @@ module Dr
 
               clean = "sudo chroot #{br} apt-get clean"
               apt = "sudo chroot #{br} apt-get update"
+              # FIXME: To install the dependencies, we use both the
+              #        `apt-get build-dep` tool to attempt to download the
+              #        packages first as well as the `mk-build-deps` in case
+              #        the first command fails. Ideally, the first command
+              #        would never fail.
               deps = <<-EOS
 sudo chroot #{br} <<EOF
 dpkg-source -b "/#{build_dir_name}"
@@ -259,6 +264,7 @@ cd #{build_dir_name}
 apt-get build-dep --download-only --yes ../*.dsc
 apt-get build-dep --fix-broken --no-install-recommends --yes ../*.dsc
 cd ..
+mk-build-deps *.dsc -i -t "apt-get --no-install-recommends -y"
 rm -rf #{@name}-build-deps_*
 EOF
 EOS

--- a/lib/dr/version.rb
+++ b/lib/dr/version.rb
@@ -2,5 +2,5 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 
 module Dr
-  VERSION = "1.3.7"
+  VERSION = "1.3.8"
 end


### PR DESCRIPTION
When acquiring the build dependencies, sometimes the `apt-get build-dep`
tool fails to properly recognise the source package and so fails to
install the dependencies. Guard against this by using this method but
with a backup strategy of using the old method in event of failure.

Requires:
 - https://github.com/KanoComputing/kano-jenkins-libraries/pull/14
 - https://github.com/KanoComputing/dev-team/pull/199